### PR TITLE
fix: correct unit for mempool transactions

### DIFF
--- a/FullyNoded/View Controllers/Home/Home Screen/MainMenuViewController.swift
+++ b/FullyNoded/View Controllers/Home/Home Screen/MainMenuViewController.swift
@@ -418,7 +418,7 @@ class MainMenuViewController: UIViewController {
         
         case .memPool:
             if mempoolInfo != nil {
-                label.text = "\(mempoolInfo.mempoolCount.withCommas()) mempool"
+                label.text = "\(mempoolInfo.mempoolCount.withCommas()) transactions"
                 icon.image = UIImage(systemName: "waveform.path.ecg")
                 background.backgroundColor = .systemGreen
                 chevron.alpha = 0


### PR DESCRIPTION
Change unit for number of transactions in mempool from "mempool" to "transactions".

See attached image.

![image_123986672](https://user-images.githubusercontent.com/16291842/116423555-14309180-a841-11eb-8ba3-709d84eaefb0.JPG)
