### PR TITLE
User encrypted iCloud backup and recovery

### DIFF
--- a/FullyNoded.xcodeproj/project.pbxproj
+++ b/FullyNoded.xcodeproj/project.pbxproj
@@ -33,8 +33,9 @@
 		0A77138426AD9C5E005CC23D /* BlindPsbt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A77138326AD9C5E005CC23D /* BlindPsbt.swift */; };
 		0A77138626AE5E85005CC23D /* WalletInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A77138526AE5E85005CC23D /* WalletInfo.swift */; };
 		0A9834BF26BBC93F00BAB74E /* CoreDataiCloud.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9834BE26BBC93F00BAB74E /* CoreDataiCloud.swift */; };
-		0A9834C226BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 0A9834C026BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodeld */; };
 		0A9834C426BBCCB300BAB74E /* Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9834C326BBCCB300BAB74E /* Backup.swift */; };
+		0A9834C626BC2E6800BAB74E /* CloudKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A9834C526BC2E6700BAB74E /* CloudKit.framework */; };
+		0A9834CA26BC3CF500BAB74E /* Backup.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 0A9834C826BC3CF500BAB74E /* Backup.xcdatamodeld */; };
 		0A9FDC9126A84CE30050C4AE /* WalletTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9FDC9026A84CE30050C4AE /* WalletTypes.swift */; };
 		0AE19ED725F4AC0D000F0AD4 /* WalletRecoveryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE19ED625F4AC0D000F0AD4 /* WalletRecoveryViewController.swift */; };
 		844D2A4B2512D4F60046372E /* UTXOCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844D2A492512D4F60046372E /* UTXOCell.swift */; };
@@ -235,8 +236,9 @@
 		0A77138326AD9C5E005CC23D /* BlindPsbt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlindPsbt.swift; sourceTree = "<group>"; };
 		0A77138526AE5E85005CC23D /* WalletInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletInfo.swift; sourceTree = "<group>"; };
 		0A9834BE26BBC93F00BAB74E /* CoreDataiCloud.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataiCloud.swift; sourceTree = "<group>"; };
-		0A9834C126BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Fully_Noded_backup.xcdatamodel; sourceTree = "<group>"; };
 		0A9834C326BBCCB300BAB74E /* Backup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backup.swift; sourceTree = "<group>"; };
+		0A9834C526BC2E6700BAB74E /* CloudKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CloudKit.framework; path = System/Library/Frameworks/CloudKit.framework; sourceTree = SDKROOT; };
+		0A9834C926BC3CF500BAB74E /* Backup.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Backup.xcdatamodel; sourceTree = "<group>"; };
 		0A9FDC9026A84CE30050C4AE /* WalletTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTypes.swift; sourceTree = "<group>"; };
 		0AE19ED625F4AC0D000F0AD4 /* WalletRecoveryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletRecoveryViewController.swift; sourceTree = "<group>"; };
 		844D2A492512D4F60046372E /* UTXOCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTXOCell.swift; sourceTree = "<group>"; };
@@ -398,6 +400,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A9834C626BC2E6800BAB74E /* CloudKit.framework in Frameworks */,
 				0A1F10FD26A1AF3200BE2707 /* URKit in Frameworks */,
 				D06D788C25B817B500769157 /* LifeHash in Frameworks */,
 				D016AE7525B0284300A59E93 /* Tor.xcframework in Frameworks */,
@@ -567,7 +570,7 @@
 				D00B9A362111427200E8B95A /* Info.plist */,
 				D0AD9B6723E7ECC20032C607 /* SceneDelegate.swift */,
 				0A590356269875CB00510626 /* Extensions.swift */,
-				0A9834C026BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodeld */,
+				0A9834C826BC3CF500BAB74E /* Backup.xcdatamodeld */,
 			);
 			path = FullyNoded;
 			sourceTree = "<group>";
@@ -887,6 +890,7 @@
 		D08C1FBB211147F600B7CA79 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				0A9834C526BC2E6700BAB74E /* CloudKit.framework */,
 				D016AE7225B0284000A59E93 /* Tor.xcframework */,
 				D016AE4425AFFCA000A59E93 /* LibWally.xcframework */,
 				D026E5C7253A79DB001F1054 /* AuthenticationServices.framework */,
@@ -1154,6 +1158,7 @@
 				D0E9B63C211A94C600B416E7 /* Utilities.swift in Sources */,
 				D0C20ED424A6DFE600C62AA4 /* PeerInfo.swift in Sources */,
 				D09F9E5024B1BAC3006B588C /* SignerDetailViewController.swift in Sources */,
+				0A9834CA26BC3CF500BAB74E /* Backup.xcdatamodeld in Sources */,
 				0A1F10DE26A1A5F200BE2707 /* ChildIndexRange.swift in Sources */,
 				D09A330524A8C4F6009FA0B2 /* Wallet.swift in Sources */,
 				D039D3CA2332440D00D1ED18 /* HDMusigStruct.swift in Sources */,
@@ -1167,7 +1172,6 @@
 				D0B80A892516020A006B88F0 /* ImportXpubViewController.swift in Sources */,
 				0A1F10D826A1A54E00BE2707 /* ChildIndex.swift in Sources */,
 				D0C20EE024A6EF3800C62AA4 /* Balances.swift in Sources */,
-				0A9834C226BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodeld in Sources */,
 				D08A92B7233E113B00409D6E /* LockedViewController.swift in Sources */,
 				D039D3C823322F1300D1ED18 /* NodeStruct.swift in Sources */,
 				D08A92AD2337A63000409D6E /* DescriptorStruct.swift in Sources */,
@@ -1640,13 +1644,13 @@
 /* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
-		0A9834C026BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodeld */ = {
+		0A9834C826BC3CF500BAB74E /* Backup.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (
-				0A9834C126BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodel */,
+				0A9834C926BC3CF500BAB74E /* Backup.xcdatamodel */,
 			);
-			currentVersion = 0A9834C126BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodel */;
-			path = Fully_Noded_backup.xcdatamodeld;
+			currentVersion = 0A9834C926BC3CF500BAB74E /* Backup.xcdatamodel */;
+			path = Backup.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};

--- a/FullyNoded.xcodeproj/project.pbxproj
+++ b/FullyNoded.xcodeproj/project.pbxproj
@@ -32,6 +32,9 @@
 		0A59035D269B0CA800510626 /* InvoiceStruct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A59035C269B0CA700510626 /* InvoiceStruct.swift */; };
 		0A77138426AD9C5E005CC23D /* BlindPsbt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A77138326AD9C5E005CC23D /* BlindPsbt.swift */; };
 		0A77138626AE5E85005CC23D /* WalletInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A77138526AE5E85005CC23D /* WalletInfo.swift */; };
+		0A9834BF26BBC93F00BAB74E /* CoreDataiCloud.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9834BE26BBC93F00BAB74E /* CoreDataiCloud.swift */; };
+		0A9834C226BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 0A9834C026BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodeld */; };
+		0A9834C426BBCCB300BAB74E /* Backup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9834C326BBCCB300BAB74E /* Backup.swift */; };
 		0A9FDC9126A84CE30050C4AE /* WalletTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A9FDC9026A84CE30050C4AE /* WalletTypes.swift */; };
 		0AE19ED725F4AC0D000F0AD4 /* WalletRecoveryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE19ED625F4AC0D000F0AD4 /* WalletRecoveryViewController.swift */; };
 		844D2A4B2512D4F60046372E /* UTXOCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 844D2A492512D4F60046372E /* UTXOCell.swift */; };
@@ -231,6 +234,9 @@
 		0A59035C269B0CA700510626 /* InvoiceStruct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InvoiceStruct.swift; sourceTree = "<group>"; };
 		0A77138326AD9C5E005CC23D /* BlindPsbt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlindPsbt.swift; sourceTree = "<group>"; };
 		0A77138526AE5E85005CC23D /* WalletInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletInfo.swift; sourceTree = "<group>"; };
+		0A9834BE26BBC93F00BAB74E /* CoreDataiCloud.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataiCloud.swift; sourceTree = "<group>"; };
+		0A9834C126BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = Fully_Noded_backup.xcdatamodel; sourceTree = "<group>"; };
+		0A9834C326BBCCB300BAB74E /* Backup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Backup.swift; sourceTree = "<group>"; };
 		0A9FDC9026A84CE30050C4AE /* WalletTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletTypes.swift; sourceTree = "<group>"; };
 		0AE19ED625F4AC0D000F0AD4 /* WalletRecoveryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalletRecoveryViewController.swift; sourceTree = "<group>"; };
 		844D2A492512D4F60046372E /* UTXOCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTXOCell.swift; sourceTree = "<group>"; };
@@ -561,6 +567,7 @@
 				D00B9A362111427200E8B95A /* Info.plist */,
 				D0AD9B6723E7ECC20032C607 /* SceneDelegate.swift */,
 				0A590356269875CB00510626 /* Extensions.swift */,
+				0A9834C026BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodeld */,
 			);
 			path = FullyNoded;
 			sourceTree = "<group>";
@@ -633,6 +640,8 @@
 				D00B27BB255A27F300269B51 /* WalletURL.swift */,
 				D06D788E25B817E100769157 /* Lifehash.swift */,
 				0A3013D7266B361E004DA35C /* LndRpc.swift */,
+				0A9834BE26BBC93F00BAB74E /* CoreDataiCloud.swift */,
+				0A9834C326BBCCB300BAB74E /* Backup.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1158,6 +1167,7 @@
 				D0B80A892516020A006B88F0 /* ImportXpubViewController.swift in Sources */,
 				0A1F10D826A1A54E00BE2707 /* ChildIndex.swift in Sources */,
 				D0C20EE024A6EF3800C62AA4 /* Balances.swift in Sources */,
+				0A9834C226BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodeld in Sources */,
 				D08A92B7233E113B00409D6E /* LockedViewController.swift in Sources */,
 				D039D3C823322F1300D1ED18 /* NodeStruct.swift in Sources */,
 				D08A92AD2337A63000409D6E /* DescriptorStruct.swift in Sources */,
@@ -1176,6 +1186,7 @@
 				0A1F10E126A1A62B00BE2707 /* ChildIndexWildcard.swift in Sources */,
 				D09A330724A982F3009FA0B2 /* FullyNodedWalletsViewController.swift in Sources */,
 				D07AED042435B62B00C2FADB /* Entities.swift in Sources */,
+				0A9834BF26BBC93F00BAB74E /* CoreDataiCloud.swift in Sources */,
 				D0DBC7062501CEFE00F6787C /* VerifyTransactionViewController.swift in Sources */,
 				D0855FCA22B0CEA800DBBFC2 /* CreatePSBT.swift in Sources */,
 				0A1F110726A2783000BE2707 /* KeyType.swift in Sources */,
@@ -1205,6 +1216,7 @@
 				D02958D3234F82E000ED8F72 /* IdentityViewController.swift in Sources */,
 				0A1F10DB26A1A58100BE2707 /* GeneralError.swift in Sources */,
 				D09A330324A86C7C009FA0B2 /* Signer.swift in Sources */,
+				0A9834C426BBCCB300BAB74E /* Backup.swift in Sources */,
 				D08A92B1233B213300409D6E /* ChooseWalletViewController.swift in Sources */,
 				0A77138426AD9C5E005CC23D /* BlindPsbt.swift in Sources */,
 				D0A2918F225114670099A2F3 /* MakeRPCCall.swift in Sources */,
@@ -1628,6 +1640,16 @@
 /* End XCSwiftPackageProductDependency section */
 
 /* Begin XCVersionGroup section */
+		0A9834C026BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				0A9834C126BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodel */,
+			);
+			currentVersion = 0A9834C126BBCAD600BAB74E /* Fully_Noded_backup.xcdatamodel */;
+			path = Fully_Noded_backup.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
 		D0C4EE6D24F0EC9B003C929A /* BitSense.xcdatamodeld */ = {
 			isa = XCVersionGroup;
 			children = (

--- a/FullyNoded/AppDelegate.swift
+++ b/FullyNoded/AppDelegate.swift
@@ -36,14 +36,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidEnterBackground(_ application: UIApplication) {}
 
     func applicationWillEnterForeground(_ application: UIApplication) {
-//        if KeyChain.getData("UnlockPassword") != nil {
-//            let storyboard = UIStoryboard(name: "Main", bundle: nil)
-//            let loginVC = storyboard.instantiateViewController(withIdentifier: "LogIn")
-//            let topVC = self.window?.rootViewController?.topViewController()
-//            if topVC!.restorationIdentifier != "LogIn" {
-//                topVC!.present(loginVC, animated: true, completion: nil)
-//            }
-//        }
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {}
@@ -92,8 +84,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             } catch {
                 // Replace this implementation with code to handle the error appropriately.
                 // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
+                #if DEBUG
                 let nserror = error as NSError
                 fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+                #endif
             }
         }
     }

--- a/FullyNoded/AppDelegate.swift
+++ b/FullyNoded/AppDelegate.swift
@@ -42,6 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillTerminate(_ application: UIApplication) {
         self.saveContext()
+        //CoreDataiCloud.saveContext()
     }
 
     // MARK: - Core Data stack

--- a/FullyNoded/Backup.xcdatamodeld/Backup.xcdatamodel/contents
+++ b/FullyNoded/Backup.xcdatamodeld/Backup.xcdatamodel/contents
@@ -17,45 +17,12 @@
         <attribute name="rpcuser" optional="YES" attributeType="Binary"/>
         <attribute name="uncleJim" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
     </entity>
-    <entity name="Peers_" representedClassName="Peers_" syncable="YES" codeGenerationType="class">
-        <attribute name="alias" optional="YES" attributeType="Binary"/>
-        <attribute name="color" optional="YES" attributeType="Binary"/>
-        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="label" optional="YES" attributeType="Binary"/>
-        <attribute name="pubkey" optional="YES" attributeType="Binary"/>
-        <attribute name="uri" optional="YES" attributeType="Binary"/>
-    </entity>
     <entity name="Signers_" representedClassName="Signers_" syncable="YES" codeGenerationType="class">
         <attribute name="added" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="label" optional="YES" attributeType="Binary"/>
         <attribute name="passphrase" optional="YES" attributeType="Binary"/>
         <attribute name="words" optional="YES" attributeType="Binary"/>
-    </entity>
-    <entity name="Transactions_" representedClassName="Transactions_" syncable="YES" codeGenerationType="class">
-        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="fiatCurrency" optional="YES" attributeType="Binary"/>
-        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="label" optional="YES" attributeType="Binary"/>
-        <attribute name="memo" optional="YES" attributeType="Binary"/>
-        <attribute name="originFxRate" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <attribute name="txid" optional="YES" attributeType="Binary"/>
-        <attribute name="walletId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
-    </entity>
-    <entity name="Utxos_" representedClassName="Utxos_" syncable="YES" codeGenerationType="class">
-        <attribute name="address" optional="YES" attributeType="Binary"/>
-        <attribute name="amount" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <attribute name="confirmations" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="confs" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="desc" optional="YES" attributeType="Binary"/>
-        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
-        <attribute name="label" optional="YES" attributeType="Binary"/>
-        <attribute name="safe" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="solvable" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="spendable" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="txid" optional="YES" attributeType="Binary"/>
-        <attribute name="vout" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="walletId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
     <entity name="Wallets_" representedClassName="Wallets_" syncable="YES" codeGenerationType="class">
         <attribute name="account" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
@@ -68,15 +35,11 @@
         <attribute name="name" optional="YES" attributeType="Binary"/>
         <attribute name="receiveDescriptor" optional="YES" attributeType="Binary"/>
         <attribute name="type" optional="YES" attributeType="Binary"/>
-        <attribute name="watching" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
     </entity>
     <elements>
         <element name="AuthKeys_" positionX="-54" positionY="-9" width="128" height="74"/>
         <element name="Nodes_" positionX="-36" positionY="36" width="128" height="14"/>
-        <element name="Peers_" positionX="-18" positionY="45" width="128" height="14"/>
         <element name="Signers_" positionX="0" positionY="54" width="128" height="14"/>
-        <element name="Transactions_" positionX="18" positionY="72" width="128" height="14"/>
-        <element name="Utxos_" positionX="36" positionY="90" width="128" height="14"/>
-        <element name="Wallets_" positionX="-9" positionY="45" width="128" height="14"/>
+        <element name="Wallets_" positionX="-9" positionY="45" width="128" height="179"/>
     </elements>
 </model>

--- a/FullyNoded/Backup.xcdatamodeld/Backup.xcdatamodel/contents
+++ b/FullyNoded/Backup.xcdatamodeld/Backup.xcdatamodel/contents
@@ -10,7 +10,7 @@
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="isActive" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
         <attribute name="isLightning" optional="YES" attributeType="Boolean" usesScalarValueType="YES"/>
-        <attribute name="label" optional="YES" attributeType="Binary"/>
+        <attribute name="label" optional="YES" attributeType="String"/>
         <attribute name="macaroon" optional="YES" attributeType="Binary"/>
         <attribute name="onionAddress" optional="YES" attributeType="Binary"/>
         <attribute name="rpcpassword" optional="YES" attributeType="Binary"/>
@@ -39,7 +39,7 @@
         <attribute name="label" optional="YES" attributeType="Binary"/>
         <attribute name="memo" optional="YES" attributeType="Binary"/>
         <attribute name="originFxRate" optional="YES" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
-        <attribute name="txid" optional="YES" attributeType="String"/>
+        <attribute name="txid" optional="YES" attributeType="Binary"/>
         <attribute name="walletId" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
     </entity>
     <entity name="Utxos_" representedClassName="Utxos_" syncable="YES" codeGenerationType="class">
@@ -59,7 +59,7 @@
     </entity>
     <entity name="Wallets_" representedClassName="Wallets_" syncable="YES" codeGenerationType="class">
         <attribute name="account" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="blockheight" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="blockheight" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="changeDescriptor" optional="YES" attributeType="Binary"/>
         <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
         <attribute name="index" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
@@ -71,12 +71,12 @@
         <attribute name="watching" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData"/>
     </entity>
     <elements>
-        <element name="AuthKeys_" positionX="-54" positionY="-18" width="128" height="74"/>
-        <element name="Nodes_" positionX="-36" positionY="54" width="128" height="179"/>
-        <element name="Peers_" positionX="-18" positionY="117" width="128" height="119"/>
-        <element name="Signers_" positionX="0" positionY="135" width="128" height="104"/>
-        <element name="Transactions_" positionX="18" positionY="144" width="128" height="149"/>
-        <element name="Utxos_" positionX="36" positionY="180" width="128" height="224"/>
-        <element name="Wallets_" positionX="-9" positionY="144" width="128" height="194"/>
+        <element name="AuthKeys_" positionX="-54" positionY="-9" width="128" height="74"/>
+        <element name="Nodes_" positionX="-36" positionY="36" width="128" height="14"/>
+        <element name="Peers_" positionX="-18" positionY="45" width="128" height="14"/>
+        <element name="Signers_" positionX="0" positionY="54" width="128" height="14"/>
+        <element name="Transactions_" positionX="18" positionY="72" width="128" height="14"/>
+        <element name="Utxos_" positionX="36" positionY="90" width="128" height="14"/>
+        <element name="Wallets_" positionX="-9" positionY="45" width="128" height="14"/>
     </elements>
 </model>

--- a/FullyNoded/Base.lproj/Main.storyboard
+++ b/FullyNoded/Base.lproj/Main.storyboard
@@ -5867,15 +5867,28 @@ COLD means no keys will be generated and no private keys can be imported.</strin
                                     <action selector="showGuideAction:" destination="B99-yZ-naR" eventType="touchUpInside" id="gLf-qJ-WNO"/>
                                 </connections>
                             </button>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="leading" contentVerticalAlignment="center" showsTouchWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UFY-wL-O3m">
+                                <rect key="frame" x="67" y="582" width="241" height="40"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="241" id="2O6-yZ-vES"/>
+                                    <constraint firstAttribute="height" constant="40" id="LiW-9J-G1x"/>
+                                </constraints>
+                                <state key="normal" title="  recover from iCloud" image="icloud.and.arrow.down" catalog="system"/>
+                                <connections>
+                                    <action selector="recoverAction:" destination="B99-yZ-naR" eventType="touchUpInside" id="lh5-11-Kow"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="uUf-aQ-0bN"/>
                         <color key="backgroundColor" red="0.050706155598163605" green="0.058625258505344391" blue="0.071102283895015717" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
+                            <constraint firstItem="UFY-wL-O3m" firstAttribute="centerX" secondItem="B9e-yr-KMo" secondAttribute="centerX" id="8Mp-hf-PNm"/>
                             <constraint firstItem="qBh-RP-hWz" firstAttribute="top" secondItem="DTI-AZ-owi" secondAttribute="bottom" constant="7.5" id="ACa-qM-sgb"/>
                             <constraint firstItem="uUf-aQ-0bN" firstAttribute="trailing" secondItem="qBh-RP-hWz" secondAttribute="trailing" constant="16" id="HV2-84-YUw"/>
                             <constraint firstItem="DTI-AZ-owi" firstAttribute="leading" secondItem="uUf-aQ-0bN" secondAttribute="leading" constant="16" id="RC6-xc-GeH"/>
                             <constraint firstItem="qBh-RP-hWz" firstAttribute="leading" secondItem="uUf-aQ-0bN" secondAttribute="leading" constant="16" id="gOe-Le-cG0"/>
                             <constraint firstItem="DTI-AZ-owi" firstAttribute="top" secondItem="uUf-aQ-0bN" secondAttribute="top" constant="11" id="kzr-7F-vnw"/>
+                            <constraint firstItem="UFY-wL-O3m" firstAttribute="top" secondItem="4Lc-CO-CxA" secondAttribute="bottom" constant="8" symbolic="YES" id="nGo-sx-SQx"/>
                             <constraint firstItem="4Lc-CO-CxA" firstAttribute="top" secondItem="qBh-RP-hWz" secondAttribute="bottom" constant="12" id="s6S-H3-wnk"/>
                             <constraint firstItem="4Lc-CO-CxA" firstAttribute="centerX" secondItem="B9e-yr-KMo" secondAttribute="centerX" id="y0W-9T-Qx7"/>
                         </constraints>
@@ -7632,8 +7645,8 @@ COLD means no keys will be generated and no private keys can be imported.</strin
         <segue reference="Cd3-qW-ujG"/>
         <segue reference="IAz-j1-Gq6"/>
         <segue reference="6KH-E3-p33"/>
-        <segue reference="CQp-9r-70w"/>
-        <segue reference="7UD-TA-0Dv"/>
+        <segue reference="07E-4w-Zh7"/>
+        <segue reference="8MS-xS-DMP"/>
         <segue reference="yAt-Ra-aPH"/>
         <segue reference="7PS-EL-3d2"/>
         <segue reference="Ikt-mc-dmE"/>
@@ -7664,6 +7677,7 @@ COLD means no keys will be generated and no private keys can be imported.</strin
         <image name="folder" catalog="system" width="128" height="97"/>
         <image name="gear" catalog="system" width="128" height="119"/>
         <image name="hifispeaker" catalog="system" width="111" height="128"/>
+        <image name="icloud.and.arrow.down" catalog="system" width="128" height="112"/>
         <image name="info.circle" catalog="system" width="128" height="121"/>
         <image name="link" catalog="system" width="128" height="122"/>
         <image name="lock" catalog="system" width="128" height="128"/>

--- a/FullyNoded/Extensions.swift
+++ b/FullyNoded/Extensions.swift
@@ -490,3 +490,11 @@ public extension UIDevice {
     }()
     
 }
+
+//extension DispatchQueue {
+//    static func background(background: (()->Void)? = nil) {
+//        DispatchQueue.global(qos: .background).async {
+//            //background?()
+//        }
+//    }
+//}

--- a/FullyNoded/Extensions.swift
+++ b/FullyNoded/Extensions.swift
@@ -492,9 +492,14 @@ public extension UIDevice {
 }
 
 //extension DispatchQueue {
-//    static func background(background: (()->Void)? = nil) {
+//    static func background(delay: Double = 0.0, background: (()->Void)? = nil, completion: (() -> Void)? = nil) {
 //        DispatchQueue.global(qos: .background).async {
-//            //background?()
+//            background?()
+//            if let completion = completion {
+//                DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: {
+//                    completion()
+//                })
+//            }
 //        }
 //    }
 //}

--- a/FullyNoded/FullyNoded.entitlements
+++ b/FullyNoded/FullyNoded.entitlements
@@ -2,12 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.fullynoded.backup</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.fontaine.fullynoded</string>
+	</array>
 	<key>com.apple.security.assets.pictures.read-write</key>
 	<true/>
 	<key>com.apple.security.device.camera</key>
@@ -23,6 +37,8 @@
 	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
 	<key>keychain-access-groups</key>
-	<array/>
+	<array>
+		<string>$(AppIdentifierPrefix)com.fontaine.FullyNoded</string>
+	</array>
 </dict>
 </plist>

--- a/FullyNoded/FullyNodedRelease.entitlements
+++ b/FullyNoded/FullyNodedRelease.entitlements
@@ -2,12 +2,26 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>development</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>
 	</array>
+	<key>com.apple.developer.icloud-container-identifiers</key>
+	<array>
+		<string>iCloud.com.fullynoded.backup</string>
+	</array>
+	<key>com.apple.developer.icloud-services</key>
+	<array>
+		<string>CloudKit</string>
+	</array>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.fontaine.fullynoded</string>
+	</array>
 	<key>com.apple.security.assets.pictures.read-write</key>
 	<true/>
 	<key>com.apple.security.device.camera</key>
@@ -21,6 +35,8 @@
 	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
 	<key>keychain-access-groups</key>
-	<array/>
+	<array>
+		<string>$(AppIdentifierPrefix)com.fontaine.FullyNoded</string>
+	</array>
 </dict>
 </plist>

--- a/FullyNoded/Fully_Noded_backup.xcdatamodeld/.xccurrentversion
+++ b/FullyNoded/Fully_Noded_backup.xcdatamodeld/.xccurrentversion
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/FullyNoded/Fully_Noded_backup.xcdatamodeld/Fully_Noded_backup.xcdatamodel/contents
+++ b/FullyNoded/Fully_Noded_backup.xcdatamodeld/Fully_Noded_backup.xcdatamodel/contents
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="18154" systemVersion="20B29" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="Backup" representedClassName="Backup" syncable="YES" codeGenerationType="class">
+        <attribute name="authkeys" optional="YES" attributeType="Binary"/>
+        <attribute name="nodes" optional="YES" attributeType="Binary"/>
+        <attribute name="signers" optional="YES" attributeType="Binary"/>
+        <attribute name="transactions" optional="YES" attributeType="Binary"/>
+        <attribute name="utxos" optional="YES" attributeType="Binary"/>
+        <attribute name="wallets" optional="YES" attributeType="Binary"/>
+    </entity>
+    <elements>
+        <element name="Backup" positionX="-63" positionY="-18" width="128" height="14"/>
+    </elements>
+</model>

--- a/FullyNoded/Helpers/Backup.swift
+++ b/FullyNoded/Helpers/Backup.swift
@@ -40,6 +40,21 @@ class BackupiCloud {
     static func backup(encryptionKey: Data, completion: @escaping ((backedup: Bool, message: String?)) -> Void) {
         var saved = true
         
+        let sha = Crypto.sha256hash(encryptionKey)
+        
+        if let existing = KeyChain.getData("iCloudSHA") {
+            guard existing == Crypto.sha256hash(sha) else {
+                completion((false, "Provided encryption key does not match last used encryption key."))
+                return
+            }
+            
+        } else {
+            guard KeyChain.set(Crypto.sha256hash(sha), forKey: "iCloudSHA") else {
+                completion((false, "Unable to save hash..."))
+                return
+            }
+        }
+        
         let entities:[ENTITY] = [
             .authKeys,
             .newNodes,
@@ -294,6 +309,21 @@ class BackupiCloud {
     }
     
     static func recover(passwordHash: Data, completion: @escaping ((recovered: Bool, message: String?)) -> Void) {
+        let sha = Crypto.sha256hash(passwordHash)
+        
+        if let existing = KeyChain.getData("iCloudSHA") {
+            guard existing == Crypto.sha256hash(sha) else {
+                completion((false, "Provided encryption key does not match last used encryption key."))
+                return
+            }
+            
+        } else {
+            guard KeyChain.set(Crypto.sha256hash(sha), forKey: "iCloudSHA") else {
+                completion((false, "Unable to save hash..."))
+                return
+            }
+        }
+        
         var dataToRecover = [String:Any]()
         
         let entities:[ENTITY_BACKUP] = [

--- a/FullyNoded/Helpers/Backup.swift
+++ b/FullyNoded/Helpers/Backup.swift
@@ -1,0 +1,46 @@
+//
+//  Backup.swift
+//  FullyNoded
+//
+//  Created by Peter Denton on 8/5/21.
+//  Copyright © 2021 Fontaine. All rights reserved.
+//
+
+import Foundation
+
+class BackupiCloud {
+        
+    static func backup(completion: @escaping ((Bool)) -> Void) {
+        
+        var dataArray = [[String:Any]]()
+        
+        let entities:[ENTITY] = [
+            .authKeys,
+            .newNodes,
+            .peers,
+            .signers,
+            .transactions,
+            .utxos,
+            .wallets
+        ]
+        
+        for entity in entities {
+            CoreDataService.retrieveEntity(entityName: entity) { data in
+                guard let data = data else { return }
+                
+                print("\(entity.rawValue): \(data)")
+                
+//                switch entity {
+//                case .authKeys:
+//
+//
+//                }
+                                
+                //dataArray.append(["\(entity.rawValue)": data])
+                //CoreDataiCloud.saveEntity(dict: <#T##[String : Any]#>, completion: <#T##((success: Bool, errorDescription: String?)) -> Void#>)
+            }
+        }
+    }
+    
+    
+}

--- a/FullyNoded/Helpers/Backup.swift
+++ b/FullyNoded/Helpers/Backup.swift
@@ -11,8 +11,7 @@ import Foundation
 class BackupiCloud {
         
     static func backup(completion: @escaping ((Bool)) -> Void) {
-        
-        var dataArray = [[String:Any]]()
+        var dataToBackup = [String:Any]()
         
         let entities:[ENTITY] = [
             .authKeys,
@@ -24,23 +23,126 @@ class BackupiCloud {
             .wallets
         ]
         
-        for entity in entities {
-            CoreDataService.retrieveEntity(entityName: entity) { data in
-                guard let data = data else { return }
+        for (x, entity) in entities.enumerated() {
+            CoreDataService.retrieveEntity(entityName: entity) { dictArray in
+                guard let dictArray = dictArray else { return }
                 
-                print("\(entity.rawValue): \(data)")
+                var newArray = [[String:Any]]()
+                newArray = dictArray
                 
-//                switch entity {
-//                case .authKeys:
-//
-//
-//                }
+                DispatchQueue.global(qos: .background).async {
+                    for (i, dict) in dictArray.enumerated() {
+                        for (key, value) in dict {
+                            if key == "watching" {
+                                if let array = value as? NSArray {
+                                    var encryptedArray = [Data]()
+                                    for (d, descriptor) in array.enumerated() {
+                                        if let encrypted = Crypto.encryptForBackup((descriptor as! String).utf8) {
+                                            encryptedArray.append(encrypted)
+                                            if d + 1 == array.count {
+                                                newArray[i]["\(key)"] = encryptedArray
+                                            }
+                                        }
+                                    }
+                                }
+                            } else if let string = value as? String {
+                                if !(entity == .newNodes && key == "label") {
+                                    if let encrypted = Crypto.encryptForBackup(string.utf8) {
+                                        newArray[i]["\(key)"] = encrypted
+                                    }
+                                }
+                            } else if let data = value as? Data {
+                                if let decrypted = Crypto.decrypt(data) {
+                                    if let encrypted = Crypto.encryptForBackup(decrypted) {
+                                        newArray[i]["\(key)"] = encrypted
+                                    }
+                                }
+                            }
+                            
+                            if i + 1 == dictArray.count {
+                                var newKey:ENTITY_BACKUP!
                                 
-                //dataArray.append(["\(entity.rawValue)": data])
-                //CoreDataiCloud.saveEntity(dict: <#T##[String : Any]#>, completion: <#T##((success: Bool, errorDescription: String?)) -> Void#>)
+                                switch entity {
+                                case .authKeys:
+                                    newKey = .authKeys
+                                case .newNodes:
+                                    newKey = .nodes
+                                case .peers:
+                                    newKey = .peers
+                                case .signers:
+                                    newKey = .signers
+                                case .transactions:
+                                    newKey = .transactions
+                                case .utxos:
+                                    newKey = .utxos
+                                case .wallets:
+                                    newKey = .wallets
+                                }
+                                
+                                dataToBackup["\(newKey.rawValue)"] = newArray
+                                
+                                if x + 1 == entities.count {
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                        save(dataToBackup, completion: completion)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
             }
         }
     }
     
+    static func save(_ dataToBackup: [String:Any], completion: @escaping ((Bool)) -> Void) {
+        for (key, value) in dataToBackup {
+            var savedAll = true
+            if let dictArray = value as? [[String:Any]], let entity = ENTITY_BACKUP(rawValue: key) {
+                for (i, dict) in dictArray.enumerated() {
+                    CoreDataiCloud.deleteEntity(entity: entity) { deleted in
+                        if deleted {
+                            CoreDataiCloud.saveEntity(entity: entity, dict: dict) { saved in
+                                if !saved {
+                                    savedAll = false
+                                }
+                                if i + 1 == dictArray.count {
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                                        completion((savedAll))
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
     
+    static func destroy(completion: @escaping ((Bool)) -> Void) {
+        let entities:[ENTITY_BACKUP] = [
+            .authKeys,
+            .nodes,
+            .peers,
+            .signers,
+            .transactions,
+            .utxos,
+            .wallets
+        ]
+        
+        var deletedAll = true
+        
+        for (i, entity) in entities.enumerated() {
+            CoreDataiCloud.deleteEntity(entity: entity) { deleted in
+                if !deleted {
+                    deletedAll = false
+                }
+                
+                if i + 1 == entities.count {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        completion((deletedAll))
+                    }
+                }
+            }
+        }
+    }
 }

--- a/FullyNoded/Helpers/CoreDataiCloud.swift
+++ b/FullyNoded/Helpers/CoreDataiCloud.swift
@@ -1,0 +1,169 @@
+//
+//  CoreDataiCloud.swift
+//  FullyNoded
+//
+//  Created by Peter Denton on 8/5/21.
+//  Copyright © 2021 Fontaine. All rights reserved.
+//
+
+import Foundation
+import CoreData
+
+class CoreDataiCloud {
+    
+    static var persistentContainer: NSPersistentCloudKitContainer = {
+        let container = NSPersistentCloudKitContainer(name: "Fully_Noded_backup")
+        
+        guard let description = container.persistentStoreDescriptions.first else {
+            fatalError("Could not retrieve a persistent store description.")
+        }
+        
+        description.cloudKitContainerOptions = NSPersistentCloudKitContainerOptions(containerIdentifier: "iCloud.com.fullynoded.backup")
+        
+        container.loadPersistentStores(completionHandler: { (storeDescription, error) in
+            if let error = error as NSError? {
+                fatalError("Unresolved error \(error), \(error.userInfo)")
+            }
+        })
+        return container
+    }()
+    
+    static var viewContext: NSManagedObjectContext {
+        let viewContext = CoreDataiCloud.persistentContainer.viewContext
+        viewContext.automaticallyMergesChangesFromParent = true
+        return viewContext
+    }
+        
+    class func saveContext () {
+        DispatchQueue.main.async {
+            let context = CoreDataiCloud.viewContext
+            if context.hasChanges {
+                do {
+                    try context.save()
+                } catch {
+                    let nserror = error as NSError
+                    fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+                }
+            }
+        }
+    }
+    
+    class func saveEntity(dict: [String:Any], completion: @escaping ((Bool)) -> Void) {
+        DispatchQueue.main.async {
+            let context = CoreDataiCloud.viewContext
+            
+            guard let entity = NSEntityDescription.entity(forEntityName: "ENTITY_BACKUP", in: context) else {
+                completion((false))
+                return
+            }
+
+            let credential = NSManagedObject(entity: entity, insertInto: context)
+            var success = false
+
+            for (key, value) in dict {
+                credential.setValue(value, forKey: key)
+                do {
+                    try context.save()
+                    success = true
+                } catch {
+                }
+            }
+            completion(success)
+        }
+    }
+    
+    class func deleteEntity(completion: @escaping ((Bool)) -> Void) {
+        DispatchQueue.main.async {
+            let context = CoreDataiCloud.viewContext
+            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ENTITY_BACKUP")
+            fetchRequest.returnsObjectsAsFaults = false
+            do {
+                let stuff = try context.fetch(fetchRequest)
+                for thing in stuff as! [NSManagedObject] {
+                    context.delete(thing)
+                }
+                try context.save()
+                completion(true)
+            } catch {
+                completion(false)
+            }
+        }
+    }
+    
+    class func retrieveEntity(completion: @escaping ((entity: [[String:Any]]?, errorDescription: String?)) -> Void) {
+        DispatchQueue.main.async {
+            let context = CoreDataiCloud.viewContext
+            var fetchRequest:NSFetchRequest<NSFetchRequestResult>? = NSFetchRequest<NSFetchRequestResult>(entityName: "ENTITY_BACKUP")
+            fetchRequest?.returnsObjectsAsFaults = false
+            fetchRequest?.resultType = .dictionaryResultType
+            
+            do {
+                if fetchRequest != nil {
+                    if let results = try context.fetch(fetchRequest!) as? [[String:Any]] {
+                        fetchRequest = nil
+                        completion((results, nil))
+                    } else {
+                        fetchRequest = nil
+                        completion((nil, "error fetching entity"))
+                    }
+                }
+            } catch {
+                fetchRequest = nil
+                completion((nil, "Error fetching QR"))
+            }
+        }
+    }
+        
+//    class func updateEntity(id: UUID, keyToUpdate: String, newValue: Any, completion: @escaping ((success: Bool, errorDescription: String?)) -> Void) {
+//        DispatchQueue.main.async {
+//            let context = CoreDataiCloud.viewContext
+//            var fetchRequest:NSFetchRequest<NSManagedObject>? = NSFetchRequest<NSManagedObject>(entityName: "QR")
+//            fetchRequest?.returnsObjectsAsFaults = false
+//
+//            do {
+//                if fetchRequest != nil {
+//                    var results:[NSManagedObject]? = try context.fetch(fetchRequest!)
+//                    if results != nil {
+//                        if results!.count > 0 {
+//                            var success = false
+//                            for (i, data) in results!.enumerated() {
+//                                if id == data.value(forKey: "id") as? UUID {
+//                                    data.setValue(newValue, forKey: keyToUpdate)
+//                                    do {
+//                                        try context.save()
+//                                        success = true
+//
+//                                    } catch {
+//                                        success = false
+//
+//                                    }
+//                                }
+//                                if i + 1 == results!.count {
+//                                    fetchRequest = nil
+//                                    results = nil
+//                                    if success {
+//                                        #if DEBUG
+//                                        print("updated successfully")
+//                                        #endif
+//                                        completion((true, nil))
+//
+//                                    } else {
+//                                        completion((false, "error editing"))
+//
+//                                    }
+//                                }
+//                            }
+//                        } else {
+//                            completion((false, "no results"))
+//
+//                        }
+//                    }
+//                }
+//            } catch {
+//                completion((false, "failed"))
+//
+//            }
+//        }
+//    }
+    
+}

--- a/FullyNoded/Helpers/CoreDataiCloud.swift
+++ b/FullyNoded/Helpers/CoreDataiCloud.swift
@@ -93,7 +93,7 @@ class CoreDataiCloud {
         }
     }
     
-    class func retrieveEntity(entity: ENTITY_BACKUP, completion: @escaping ((entity: [[String:Any]]?, errorDescription: String?)) -> Void) {
+    class func retrieveEntity(entity: ENTITY_BACKUP, completion: @escaping (([[String:Any]]?)) -> Void) {
         DispatchQueue.main.async {
             let context = CoreDataiCloud.viewContext
             var fetchRequest:NSFetchRequest<NSFetchRequestResult>? = NSFetchRequest<NSFetchRequestResult>(entityName: entity.rawValue)
@@ -104,15 +104,15 @@ class CoreDataiCloud {
                 if fetchRequest != nil {
                     if let results = try context.fetch(fetchRequest!) as? [[String:Any]] {
                         fetchRequest = nil
-                        completion((results, nil))
+                        completion((results))
                     } else {
                         fetchRequest = nil
-                        completion((nil, "error fetching entity"))
+                        completion((nil))
                     }
                 }
             } catch {
                 fetchRequest = nil
-                completion((nil, "Error fetching QR"))
+                completion((nil))
             }
         }
     }

--- a/FullyNoded/Helpers/CoreDataiCloud.swift
+++ b/FullyNoded/Helpers/CoreDataiCloud.swift
@@ -12,7 +12,7 @@ import CoreData
 class CoreDataiCloud {
     
     static var persistentContainer: NSPersistentCloudKitContainer = {
-        let container = NSPersistentCloudKitContainer(name: "Fully_Noded_backup")
+        let container = NSPersistentCloudKitContainer(name: "Backup")
         
         guard let description = container.persistentStoreDescriptions.first else {
             fatalError("Could not retrieve a persistent store description.")
@@ -20,9 +20,11 @@ class CoreDataiCloud {
         
         description.cloudKitContainerOptions = NSPersistentCloudKitContainerOptions(containerIdentifier: "iCloud.com.fullynoded.backup")
         
+        
         container.loadPersistentStores(completionHandler: { (storeDescription, error) in
             if let error = error as NSError? {
-                fatalError("Unresolved error \(error), \(error.userInfo)")
+                //fatalError("Unresolved error \(error), \(error.userInfo)")
+                print("Unresolved error \(error), \(error.userInfo)")
             }
         })
         return container
@@ -34,7 +36,7 @@ class CoreDataiCloud {
         return viewContext
     }
         
-    class func saveContext () {
+    class func saveContext() {
         DispatchQueue.main.async {
             let context = CoreDataiCloud.viewContext
             if context.hasChanges {
@@ -42,17 +44,18 @@ class CoreDataiCloud {
                     try context.save()
                 } catch {
                     let nserror = error as NSError
-                    fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
+                    print("Unresolved error \(nserror), \(nserror.userInfo)")
+                    //fatalError("Unresolved error \(nserror), \(nserror.userInfo)")
                 }
             }
         }
     }
     
-    class func saveEntity(dict: [String:Any], completion: @escaping ((Bool)) -> Void) {
+    class func saveEntity(entity: ENTITY_BACKUP, dict: [String:Any], completion: @escaping ((Bool)) -> Void) {
         DispatchQueue.main.async {
             let context = CoreDataiCloud.viewContext
             
-            guard let entity = NSEntityDescription.entity(forEntityName: "ENTITY_BACKUP", in: context) else {
+            guard let entity = NSEntityDescription.entity(forEntityName: entity.rawValue, in: context) else {
                 completion((false))
                 return
             }
@@ -72,10 +75,10 @@ class CoreDataiCloud {
         }
     }
     
-    class func deleteEntity(completion: @escaping ((Bool)) -> Void) {
+    class func deleteEntity(entity: ENTITY_BACKUP, completion: @escaping ((Bool)) -> Void) {
         DispatchQueue.main.async {
             let context = CoreDataiCloud.viewContext
-            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "ENTITY_BACKUP")
+            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: entity.rawValue)
             fetchRequest.returnsObjectsAsFaults = false
             do {
                 let stuff = try context.fetch(fetchRequest)
@@ -90,10 +93,10 @@ class CoreDataiCloud {
         }
     }
     
-    class func retrieveEntity(completion: @escaping ((entity: [[String:Any]]?, errorDescription: String?)) -> Void) {
+    class func retrieveEntity(entity: ENTITY_BACKUP, completion: @escaping ((entity: [[String:Any]]?, errorDescription: String?)) -> Void) {
         DispatchQueue.main.async {
             let context = CoreDataiCloud.viewContext
-            var fetchRequest:NSFetchRequest<NSFetchRequestResult>? = NSFetchRequest<NSFetchRequestResult>(entityName: "ENTITY_BACKUP")
+            var fetchRequest:NSFetchRequest<NSFetchRequestResult>? = NSFetchRequest<NSFetchRequestResult>(entityName: entity.rawValue)
             fetchRequest?.returnsObjectsAsFaults = false
             fetchRequest?.resultType = .dictionaryResultType
             

--- a/FullyNoded/Helpers/Crypto.swift
+++ b/FullyNoded/Helpers/Crypto.swift
@@ -27,6 +27,12 @@ enum Crypto {
         return P256.Signing.PrivateKey().rawRepresentation
     }
     
+    static func encryptForBackup(_ data: Data) -> Data? {
+        guard let key = KeyChain.getData("unlockPassword") else { return nil }
+        
+        return try? ChaChaPoly.seal(data, using: SymmetricKey(data: key)).combined
+    }
+    
     static func encrypt(_ data: Data) -> Data? {
         guard let key = KeyChain.getData("privateKey") else { return nil }
         

--- a/FullyNoded/Helpers/Crypto.swift
+++ b/FullyNoded/Helpers/Crypto.swift
@@ -27,15 +27,12 @@ enum Crypto {
         return P256.Signing.PrivateKey().rawRepresentation
     }
     
-    static func encryptForBackup(_ data: Data) -> Data? {
-        guard let key = KeyChain.getData("UnlockPassword") else { return nil }
-                
+    static func encryptForBackup(_ key: Data, _ data: Data) -> Data? {
         return try? ChaChaPoly.seal(data, using: SymmetricKey(data: key)).combined
     }
     
-    static func decryptForBackup(_ data: Data) -> Data? {
-        guard let key = KeyChain.getData("UnlockPassword"),
-            let box = try? ChaChaPoly.SealedBox.init(combined: data) else {
+    static func decryptForBackup(_ key: Data, _ data: Data) -> Data? {
+        guard let box = try? ChaChaPoly.SealedBox.init(combined: data) else {
                 return nil
         }
         

--- a/FullyNoded/Helpers/Crypto.swift
+++ b/FullyNoded/Helpers/Crypto.swift
@@ -28,9 +28,18 @@ enum Crypto {
     }
     
     static func encryptForBackup(_ data: Data) -> Data? {
-        guard let key = KeyChain.getData("unlockPassword") else { return nil }
-        
+        guard let key = KeyChain.getData("UnlockPassword") else { return nil }
+                
         return try? ChaChaPoly.seal(data, using: SymmetricKey(data: key)).combined
+    }
+    
+    static func decryptForBackup(_ data: Data) -> Data? {
+        guard let key = KeyChain.getData("UnlockPassword"),
+            let box = try? ChaChaPoly.SealedBox.init(combined: data) else {
+                return nil
+        }
+        
+        return try? ChaChaPoly.open(box, using: SymmetricKey(data: key))
     }
     
     static func encrypt(_ data: Data) -> Data? {
@@ -83,7 +92,7 @@ enum Crypto {
         // Goal is to replace this with a get request to my own server behind an authenticated v3 onion
         guard KeyChain.getData("blindingKey") == nil else { return true }
         
-        guard let pk = Data(base64Encoded: "NZdDCNBFTDqKPrUG9V80g0iVemSXLL0CuaWj12xqD00=") else { return false }
+        guard let pk = Data(base64Encoded: "") else { return false }
 
         return KeyChain.set(pk, forKey: "blindingKey")
     }

--- a/FullyNoded/Helpers/Entities.swift
+++ b/FullyNoded/Helpers/Entities.swift
@@ -21,5 +21,11 @@ public enum ENTITY: String {
 }
 
 public enum ENTITY_BACKUP: String {
-    case backup = "Backup"
+    case nodes = "Nodes_"
+    case authKeys = "AuthKeys_"
+    case signers = "Signers_"
+    case wallets = "Wallets_"
+    case peers = "Peers_"
+    case utxos = "Utxos_"
+    case transactions = "Transactions_"
 }

--- a/FullyNoded/Helpers/Entities.swift
+++ b/FullyNoded/Helpers/Entities.swift
@@ -19,3 +19,7 @@ public enum ENTITY: String {
     case utxos = "Utxos"
     case transactions = "Transactions"
 }
+
+public enum ENTITY_BACKUP: String {
+    case backup = "Backup"
+}

--- a/FullyNoded/Helpers/Entities.swift
+++ b/FullyNoded/Helpers/Entities.swift
@@ -25,7 +25,4 @@ public enum ENTITY_BACKUP: String {
     case authKeys = "AuthKeys_"
     case signers = "Signers_"
     case wallets = "Wallets_"
-    case peers = "Peers_"
-    case utxos = "Utxos_"
-    case transactions = "Transactions_"
 }

--- a/FullyNoded/Info.plist
+++ b/FullyNoded/Info.plist
@@ -154,6 +154,10 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>remote-notification</string>
+	</array>
 	<key>UIFileSharingEnabled</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/FullyNoded/View Controllers/Home/Home Screen/MainMenuViewController.swift
+++ b/FullyNoded/View Controllers/Home/Home Screen/MainMenuViewController.swift
@@ -122,7 +122,6 @@ class MainMenuViewController: UIViewController {
         }
     }
     
-    
     @IBAction func goToTools(_ sender: Any) {
         goToToolsCheck()
     }
@@ -655,7 +654,7 @@ class MainMenuViewController: UIViewController {
                 
                 self.feeInfo = FeeInfo(dictionary: response)
                 self.mainMenu.reloadSections(IndexSet(arrayLiteral: 11, 1), with: .fade)
-                self.removeLoader()
+                self.removeLoader()                
             }
         }
     }

--- a/FullyNoded/View Controllers/Home/Home Screen/MainMenuViewController.swift
+++ b/FullyNoded/View Controllers/Home/Home Screen/MainMenuViewController.swift
@@ -90,10 +90,6 @@ class MainMenuViewController: UIViewController {
         torProgressLabel.layer.zPosition = 1
         progressView.layer.zPosition = 1
         progressView.setNeedsFocusUpdate()
-        
-        BackupiCloud.backup { success in
-            print("backed up: \(success)")
-        }
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/FullyNoded/View Controllers/Home/Home Screen/MainMenuViewController.swift
+++ b/FullyNoded/View Controllers/Home/Home Screen/MainMenuViewController.swift
@@ -90,6 +90,10 @@ class MainMenuViewController: UIViewController {
         torProgressLabel.layer.zPosition = 1
         progressView.layer.zPosition = 1
         progressView.setNeedsFocusUpdate()
+        
+        BackupiCloud.backup { success in
+            print("backed up: \(success)")
+        }
     }
     
     override func viewDidAppear(_ animated: Bool) {

--- a/FullyNoded/View Controllers/Settings/SettingsViewController.swift
+++ b/FullyNoded/View Controllers/Settings/SettingsViewController.swift
@@ -429,11 +429,11 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
             
             let tit = "Create/update iCloud backup?"
             
-            let mess = "Create an independent, encrypted iCloud database using a password of your choice. If you already created a backup this updates the existing backup, it will only add new data, nothing will be deleted or overwritten.\n\nIf you forget your encryption password this backup will be completely useless! The encryption password is never saved anywhere in any form! YOU MUST SAVE IT OFFLINE IN ORDER TO RECOVER YOUR BACKUP!\n\nThis backs up signers, nodes, wallets, and Tor auth keys."
+            let mess = "Create an independent, encrypted iCloud database using a password of your choice. If you already created a backup this updates it.\n\nIf you forget your encryption password this backup will be completely useless! YOU MUST SAVE THE ENCRYPTION PASSWORD OFFLINE IN ORDER TO RECOVER YOUR BACKUP\n\nThis backs up signers, nodes, wallets, and Tor auth keys."
             
             let alert = UIAlertController(title: tit, message: mess, preferredStyle: .alert)
             
-            alert.addAction(UIAlertAction(title: "Create iCloud backup", style: .default, handler: { action in
+            alert.addAction(UIAlertAction(title: "Create/update backup", style: .default, handler: { action in
                 self.confirmiCloudEnable()
             }))
             
@@ -491,7 +491,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
             
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
             
-            let enable = UIAlertAction(title: "Create", style: .default) { [weak self] alertAction in
+            let enable = UIAlertAction(title: "Create/update", style: .default) { [weak self] alertAction in
                 guard let self = self else { return }
                 
                 let text = (alert.textFields![0] as UITextField).text
@@ -545,7 +545,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
             DispatchQueue.main.async { [weak self] in
                 guard let self = self else { return }
                 
-                UserDefaults.standard.setValue(true, forKey: "iCloudBackup")
+                showAlert(vc: self, title: "", message: "Encrypted iCloud backup updated ✓")
                 self.settingsTable.reloadSections(IndexSet(arrayLiteral: 1), with: .none)
             }
         }
@@ -556,7 +556,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
             guard let self = self else { return }
             
             let title = "Recover iCloud backup?"
-            let message = "Input the encryption password that was used when you created this backup."
+            let message = "Input the encryption password that was used when you created this backup. Inputting the incorrect password here means your recovery data will get bricked."
             
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
             
@@ -564,10 +564,13 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                 guard let self = self else { return }
                 
                 let text = (alert.textFields![0] as UITextField).text
+                let confirmText = (alert.textFields![1] as UITextField).text
                 
                 guard let text = text,
+                      let confirmText = confirmText,
+                      text == confirmText,
                       let hash = self.hash(text) else {
-                    showAlert(vc: self, title: "", message: "Incorrect password.")
+                    showAlert(vc: self, title: "", message: "Passwords don't match.")
                     
                     return
                 }
@@ -590,6 +593,12 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
             
             alert.addTextField { textField in
                 textField.placeholder = "encryption password"
+                textField.isSecureTextEntry = true
+                textField.keyboardAppearance = .dark
+            }
+            
+            alert.addTextField { textField in
+                textField.placeholder = "confirm password"
                 textField.isSecureTextEntry = true
                 textField.keyboardAppearance = .dark
             }

--- a/FullyNoded/View Controllers/Settings/SettingsViewController.swift
+++ b/FullyNoded/View Controllers/Settings/SettingsViewController.swift
@@ -385,7 +385,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                 case 3:
                     confirmiCloudRecovery()
                 case 4:
-                    promptToDisableiCloud()
+                    promptToDeleteiCloud()
                 default:
                     break
                 }
@@ -442,7 +442,7 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
         }
     }
     
-    private func promptToDisableiCloud() {
+    private func promptToDeleteiCloud() {
         DispatchQueue.main.async { [weak self] in
             guard let self = self else { return }
             
@@ -460,6 +460,8 @@ class SettingsViewController: UIViewController, UITableViewDelegate, UITableView
                     self.spinner.removeConnectingView()
                     
                     if destroyed {
+                        let _ = KeyChain.remove(key: "iCloudSHA")
+                        
                         showAlert(vc: self, title: "", message: "iCloud backup deleted.")
                         
                         DispatchQueue.main.async { [weak self] in

--- a/FullyNoded/View Controllers/Wallets/FullyNodedWalletsViewController.swift
+++ b/FullyNoded/View Controllers/Wallets/FullyNodedWalletsViewController.swift
@@ -37,11 +37,11 @@ class FullyNodedWalletsViewController: UIViewController, UITableViewDelegate, UI
         fxRateLabel.alpha = 0
         fxRateLabel.text = ""
         existingActiveWalletName = UserDefaults.standard.object(forKey: "walletName") as? String ?? ""
-        spinner.addConnectingView(vc: self, description: "getting total balance...")
         initialLoad = true
     }
     
     override func viewDidAppear(_ animated: Bool) {
+        spinner.addConnectingView(vc: self, description: "getting total balance...")
         getBitcoinCoreWallets()
     }
     
@@ -124,7 +124,7 @@ class FullyNodedWalletsViewController: UIViewController, UITableViewDelegate, UI
     
     private func loadTotalBalance() {
         if !initialLoad {
-            spinner.addConnectingView(vc: self, description: "getting total balance...")
+            spinner.label.text = "getting total balance..."
         }
         
         FiatConverter.sharedInstance.getFxRate { [weak self] fxRate in


### PR DESCRIPTION
This PR adds a flexible, powerful and highly secure means of backing up your critical data to the iCloud.

In order to use the feature the user must enter an "encryption password".

FN hashes the password once and uses the resulting hash to encrypt and decrypt your data. FN never stores this hash or the password, therefore all iCloud functionality is 100% manual and the user must initiate any action by going to settings and tapping the actions.

FN hashes the hash of your password, saving the double hash to the devices local keychain so that when you go to decrypt it we can again verify the hashes match before actually attempting to decrypt data. Otherwise the user could possibly input any password and decryption would fail or a single backup would be become partially bricked with multiple encryption keys.

To reset the double hash used for verification you need to delete the iCloud backup, no password required to do so.

For kill switch functionality of the iCloud back up just tap "Delete iCloud backup". You can then create a new backup with a new password. 

It is recommended not to use the same password as your unlock password because FN remembers the hash of your unlock password which would then match the iCloud encryption key, reducing the security of your data.